### PR TITLE
Fixed Rate Limiting

### DIFF
--- a/rhombus/src/internal/database/libsql.rs
+++ b/rhombus/src/internal/database/libsql.rs
@@ -2240,6 +2240,8 @@ impl<T: LibSQLConnection + Send + Sync> Database for T {
                 SELECT opened_at
                 FROM rhombus_ticket
                 WHERE user_id = ?1
+                ORDER BY opened_at DESC
+                LIMIT 1
             ",
                 [user_id],
             )


### PR DESCRIPTION
Query was getting users oldest ticket leading to rate limiting only working on the first ticket.