### PR TITLE
Remove dependency on cmake

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -57,7 +57,6 @@
             alejandra
 
             nodejs_20
-            cmake
             sqlite
             mold
             go-task

--- a/rhombus/Cargo.toml
+++ b/rhombus/Cargo.toml
@@ -76,7 +76,7 @@ unicode-segmentation = "1.11.0"
 webpki-roots = "0.26.5"
 
 futures = { version = "0.3.30", optional = true }
-libsql = { version = "0.5.0", optional = true, features = ["encryption"] }
+libsql = { version = "0.5.0", optional = true }
 listenfd = { version = "1.0.1", optional = true }
 sqlx = { version = "0.8.2", optional = true, features = [
   "tls-rustls",

--- a/rhombus/migrations/libsql/0001_setup.up.sql
+++ b/rhombus/migrations/libsql/0001_setup.up.sql
@@ -194,7 +194,7 @@ SELECT
     rhombus_division.id AS division_id,
     CASE
         WHEN rhombus_challenge.score_type = 0 THEN
-            MAX(ROUND((((100 - 500) / POWER(50, 2)) * POWER(COUNT(DISTINCT rhombus_team.id), 2)) + 500), 100)
+            MAX(ROUND((((100 - 500) / (50*50)) * (COUNT(DISTINCT rhombus_team.id) * COUNT(DISTINCT rhombus_team.id))) + 500), 100)
         ELSE rhombus_challenge.static_points
     END AS points,
     COUNT(DISTINCT rhombus_team.id) AS solves


### PR DESCRIPTION
The POWER function in libsql requires the
encryption feature which in turn requires cmake.
Replacing power will good old fashioned x*x
means we don't need cmake so it should build
succesfully in docs.rs
