### PR TITLE
Clean up dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -237,18 +237,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-hash"
-version = "0.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2200cd4d6e6c838a4e2f16aab660702a4d3e910ad769dd2f2fae922142ecdf4b"
-dependencies = [
- "futures",
- "hex",
- "num_cpus",
- "sha2",
-]
-
-[[package]]
 name = "async-imap"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2260,9 +2248,9 @@ checksum = "add0ab9360ddbd88cfeb3bd9574a1d85cfdfa14db10b3e21d3700dbc4328758f"
 
 [[package]]
 name = "http-range-header"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ce4ef31cda248bbdb6e6820603b82dfcd9e833db65a43e997a0ccec777d11fe"
+checksum = "08a397c49fec283e3d6211adbe480be95aae5f304cfb923e9970e08956d5168a"
 
 [[package]]
 name = "httparse"
@@ -3490,16 +3478,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "num_cpus"
-version = "1.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
-dependencies = [
- "hermit-abi",
- "libc",
-]
-
-[[package]]
 name = "object"
 version = "0.32.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3847,18 +3825,18 @@ checksum = "5be167a7af36ee22fe3115051bc51f6e6c7054c9348e28deb4f49bd6f705a315"
 
 [[package]]
 name = "pin-project"
-version = "1.1.5"
+version = "1.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6bf43b791c5b9e34c3d182969b4abb522f9343702850a2e57f460d00d09b4b3"
+checksum = "baf123a161dde1e524adf36f90bc5d8d3462824a9c43553ad07a8183161189ec"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.5"
+version = "1.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
+checksum = "a4502d8515ca9f32f1fb543d987f63d95a14934883db45bdb48060b6b69257f8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4500,7 +4478,6 @@ name = "rhombus"
 version = "0.2.21"
 dependencies = [
  "argon2",
- "async-hash",
  "async-imap",
  "async-trait",
  "axum 0.7.7",
@@ -4523,7 +4500,7 @@ dependencies = [
  "mime_guess",
  "minify-html-onepass",
  "minijinja",
- "pin-project-lite",
+ "pin-project",
  "poise",
  "rand",
  "reqwest 0.12.8",
@@ -6223,7 +6200,7 @@ dependencies = [
  "http 1.1.0",
  "http-body 1.0.1",
  "http-body-util",
- "http-range-header 0.4.0",
+ "http-range-header 0.4.1",
  "httpdate",
  "mime",
  "mime_guess",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,16 +3,6 @@
 version = 3
 
 [[package]]
-name = "Inflector"
-version = "0.11.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe438c63458706e03479442743baae6c88256498e6431708f6dfc520a26515d3"
-dependencies = [
- "lazy_static",
- "regex",
-]
-
-[[package]]
 name = "addr2line"
 version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -315,9 +305,9 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.82"
+version = "0.1.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a27b8a3a6e1a44fa4c8baf1f653e4172e81486d4941f2237e20dc2d0cf4ddff1"
+checksum = "721cae7de5c34fbb2acd27e21e6d2cf7b886dce0c27388d46c4e6c47ea4318dd"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -345,7 +335,7 @@ dependencies = [
  "serde",
  "serde_json",
  "url",
- "webpki-roots 0.26.5",
+ "webpki-roots 0.26.6",
 ]
 
 [[package]]
@@ -437,16 +427,16 @@ dependencies = [
 
 [[package]]
 name = "axum"
-version = "0.7.5"
+version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a6c9af12842a67734c9a2e355436e5d03b22383ed60cf13cd0c18fbfe3dcbcf"
+checksum = "504e3947307ac8326a5437504c517c4b56716c9d98fac0028c2acc7ca47d70ae"
 dependencies = [
  "async-trait",
- "axum-core 0.4.3",
+ "axum-core 0.4.5",
  "bytes",
  "futures-util",
  "http 1.1.0",
- "http-body 1.0.0",
+ "http-body 1.0.1",
  "http-body-util",
  "hyper 1.4.1",
  "hyper-util",
@@ -464,7 +454,7 @@ dependencies = [
  "serde_urlencoded",
  "sync_wrapper 1.0.1",
  "tokio",
- "tower 0.4.13",
+ "tower 0.5.1",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -489,20 +479,20 @@ dependencies = [
 
 [[package]]
 name = "axum-core"
-version = "0.4.3"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a15c63fd72d41492dc4f497196f5da1fb04fb7529e631d73630d1b491e47a2e3"
+checksum = "09f2bd6146b97ae3359fa0cc6d6b376d9539582c7b4220f041a33ec24c226199"
 dependencies = [
  "async-trait",
  "bytes",
  "futures-util",
  "http 1.1.0",
- "http-body 1.0.0",
+ "http-body 1.0.1",
  "http-body-util",
  "mime",
  "pin-project-lite",
  "rustversion",
- "sync_wrapper 0.1.2",
+ "sync_wrapper 1.0.1",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -510,22 +500,22 @@ dependencies = [
 
 [[package]]
 name = "axum-extra"
-version = "0.9.3"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0be6ea09c9b96cb5076af0de2e383bd2bc0c18f827cf1967bdd353e0b910d733"
+checksum = "73c3220b188aea709cf1b6c5f9b01c3bd936bb08bd2b5184a12b35ac8131b1f9"
 dependencies = [
- "axum 0.7.5",
- "axum-core 0.4.3",
+ "axum 0.7.7",
+ "axum-core 0.4.5",
  "bytes",
  "cookie",
  "futures-util",
  "http 1.1.0",
- "http-body 1.0.0",
+ "http-body 1.0.1",
  "http-body-util",
  "mime",
  "pin-project-lite",
  "serde",
- "tower 0.4.13",
+ "tower 0.5.1",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -822,9 +812,9 @@ checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
 
 [[package]]
 name = "bytes"
-version = "1.6.0"
+version = "1.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "514de17de45fdb8dc022b1a7975556c53c86f9f0aa5f534b98977b171857c2c9"
+checksum = "428d9aa8fbc0670b7b8d6030a7fadd0f86151cae55e4dbbece15f3780a3dfaf3"
 dependencies = [
  "serde",
 ]
@@ -1420,27 +1410,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dirs"
-version = "5.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
-dependencies = [
- "dirs-sys",
-]
-
-[[package]]
-name = "dirs-sys"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
-dependencies = [
- "libc",
- "option-ext",
- "redox_users",
- "windows-sys 0.48.0",
-]
-
-[[package]]
 name = "displaydoc"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1693,6 +1662,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "filetime"
+version = "0.2.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35c0522e981e68cbfa8c3f978441a5f34b30b96e146b33cd3359176b50fe8586"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "libredox",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "finl_unicode"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1786,9 +1767,9 @@ dependencies = [
 
 [[package]]
 name = "fontdb"
-version = "0.21.0"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37be9fc20d966be438cd57a45767f73349477fb0f85ce86e000557f787298afb"
+checksum = "a3a6f9af55fb97ad673fb7a69533eb2f967648a06fa21f8c9bb2cd6d33975716"
 dependencies = [
  "fontconfig-parser",
  "log",
@@ -1831,9 +1812,9 @@ checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "futures"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "645c6916888f6cb6350d2550b80fb63e734897a8498abe35cfb732b6487804b0"
+checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1846,9 +1827,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eac8f7d7865dcb88bd4373ab671c8cf4508703796caa2b1985a9ca867b3fcb78"
+checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -1856,15 +1837,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfc6580bb841c5a68e9ef15c77ccc837b40a7504914d52e47b8b0e9bbda25a1d"
+checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a576fc72ae164fca6b9db127eaa9a9dda0d61316034f33a0a0d4eda41f02b01d"
+checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -1884,15 +1865,15 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a44623e20b9681a318efdd71c299b6b222ed6f231972bfe2f224ebad6311f0c1"
+checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
+checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1901,15 +1882,15 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fb8e00e87438d937621c1c6269e53f536c14d3fbd6a042bb24879e57d474fb5"
+checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
 
 [[package]]
 name = "futures-task"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38d84fa142264698cdce1a9f9172cf383a0c82de1bddcf3092901442c4097004"
+checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
 
 [[package]]
 name = "futures-timer"
@@ -1919,9 +1900,9 @@ checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
 
 [[package]]
 name = "futures-util"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d6401deb83407ab3da39eba7e33987a73c3df0c82b4bb5813ee871c19c41d48"
+checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -2092,7 +2073,7 @@ dependencies = [
  "jaq-std",
  "jaq-syn",
  "regex",
- "reqwest 0.12.7",
+ "reqwest 0.12.8",
  "serde_json",
  "strsim",
  "surge-ping",
@@ -2250,9 +2231,9 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cac85db508abc24a2e48553ba12a996e87244a0395ce011e62b37158745d643"
+checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
  "http 1.1.0",
@@ -2267,7 +2248,7 @@ dependencies = [
  "bytes",
  "futures-core",
  "http 1.1.0",
- "http-body 1.0.0",
+ "http-body 1.0.1",
  "pin-project-lite",
 ]
 
@@ -2329,7 +2310,7 @@ dependencies = [
  "futures-channel",
  "futures-util",
  "http 1.1.0",
- "http-body 1.0.0",
+ "http-body 1.0.1",
  "httparse",
  "httpdate",
  "itoa",
@@ -2383,7 +2364,7 @@ dependencies = [
  "rustls-pki-types",
  "tokio",
  "tokio-rustls 0.25.0",
- "webpki-roots 0.26.5",
+ "webpki-roots 0.26.6",
 ]
 
 [[package]]
@@ -2403,7 +2384,7 @@ dependencies = [
  "tokio",
  "tokio-rustls 0.26.0",
  "tower-service",
- "webpki-roots 0.26.5",
+ "webpki-roots 0.26.6",
 ]
 
 [[package]]
@@ -2428,7 +2409,7 @@ dependencies = [
  "futures-channel",
  "futures-util",
  "http 1.1.0",
- "http-body 1.0.0",
+ "http-body 1.0.1",
  "hyper 1.4.1",
  "pin-project-lite",
  "socket2",
@@ -2883,9 +2864,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "lettre"
-version = "0.11.8"
+version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1658ac89b01055e3ba23d66ecf6f8b97388ebe34ce125e49f8ef71234fb8aaba"
+checksum = "69f204773bab09b150320ea1c83db41dc6ee606a4bc36dc1f43005fe7b58ce06"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2908,7 +2889,7 @@ dependencies = [
  "tokio",
  "tokio-rustls 0.26.0",
  "url",
- "webpki-roots 0.26.5",
+ "webpki-roots 0.26.6",
 ]
 
 [[package]]
@@ -2947,6 +2928,7 @@ checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
 dependencies = [
  "bitflags 2.5.0",
  "libc",
+ "redox_syscall 0.5.1",
 ]
 
 [[package]]
@@ -3182,9 +3164,9 @@ dependencies = [
 
 [[package]]
 name = "markdown"
-version = "1.0.0-alpha.20"
+version = "1.0.0-alpha.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "911a8325e6fb87b89890cd4529a2ab34c2669c026279e61c26b7140a3d821ccb"
+checksum = "a6491e6c702bf7e3b24e769d800746d5f2c06a6c6a2db7992612e0f429029e81"
 dependencies = [
  "unicode-id",
 ]
@@ -3539,12 +3521,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
-name = "option-ext"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
-
-[[package]]
 name = "ordered-multimap"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3773,20 +3749,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "petname"
-version = "2.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cd31dcfdbbd7431a807ef4df6edd6473228e94d5c805e8cf671227a21bad068"
-dependencies = [
- "anyhow",
- "clap",
- "itertools 0.12.1",
- "proc-macro2",
- "quote",
- "rand",
-]
-
-[[package]]
 name = "phf"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3946,7 +3908,7 @@ checksum = "d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec"
 name = "plugin"
 version = "0.1.0"
 dependencies = [
- "axum 0.7.5",
+ "axum 0.7.7",
  "fluent",
  "minijinja",
  "rhombus",
@@ -4315,6 +4277,15 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
+dependencies = [
+ "bitflags 1.3.2",
+]
+
+[[package]]
+name = "redox_syscall"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa"
@@ -4329,17 +4300,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "469052894dcb553421e483e4209ee581a45100d31b4018de03e5a7ad86374a7e"
 dependencies = [
  "bitflags 2.5.0",
-]
-
-[[package]]
-name = "redox_users"
-version = "0.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd283d9651eeda4b2a83a43c1c91b266c40fd76ecd39a50a8c630ae69dc72891"
-dependencies = [
- "getrandom",
- "libredox",
- "thiserror",
 ]
 
 [[package]]
@@ -4458,9 +4418,9 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.12.7"
+version = "0.12.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8f4955649ef5c38cc7f9e8aa41761d48fb9677197daea9984dc54f56aad5e63"
+checksum = "f713147fbe92361e52392c73b8c9e48c04c6625bce969ef54dc901e58e042a7b"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -4468,7 +4428,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "http 1.1.0",
- "http-body 1.0.0",
+ "http-body 1.0.1",
  "http-body-util",
  "hyper 1.4.1",
  "hyper-rustls 0.27.2",
@@ -4495,7 +4455,7 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "webpki-roots 0.26.5",
+ "webpki-roots 0.26.6",
  "windows-registry",
 ]
 
@@ -4511,9 +4471,9 @@ dependencies = [
 
 [[package]]
 name = "resvg"
-version = "0.43.0"
+version = "0.44.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7314563c59c7ce31c18e23ad3dd092c37b928a0fa4e1c0a1a6504351ab411d1"
+checksum = "4a325d5e8d1cebddd070b13f44cec8071594ab67d1012797c121f27a669b7958"
 dependencies = [
  "gif",
  "image-webp",
@@ -4539,12 +4499,11 @@ dependencies = [
 name = "rhombus"
 version = "0.2.21"
 dependencies = [
- "Inflector",
  "argon2",
  "async-hash",
  "async-imap",
  "async-trait",
- "axum 0.7.5",
+ "axum 0.7.7",
  "axum-extra",
  "chrono",
  "config",
@@ -4556,7 +4515,6 @@ dependencies = [
  "healthscript",
  "intl-memoizer",
  "jsonwebtoken",
- "lazy_static",
  "lettre",
  "libsql",
  "listenfd",
@@ -4565,11 +4523,10 @@ dependencies = [
  "mime_guess",
  "minify-html-onepass",
  "minijinja",
- "petname",
  "pin-project-lite",
  "poise",
  "rand",
- "reqwest 0.12.7",
+ "reqwest 0.12.8",
  "resvg",
  "ring",
  "rust-embed",
@@ -4582,19 +4539,18 @@ dependencies = [
  "testcontainers",
  "testcontainers-modules",
  "thiserror",
- "time",
  "tokio",
  "tokio-rustls 0.26.0",
  "tokio-util",
  "tower 0.5.1",
- "tower-http 0.5.2",
+ "tower-http 0.6.1",
  "tower-livereload",
  "tower_governor",
  "tracing",
  "unic-langid",
  "unicode-segmentation",
  "urlencoding",
- "webpki-roots 0.26.5",
+ "webpki-roots 0.26.6",
 ]
 
 [[package]]
@@ -5463,7 +5419,7 @@ dependencies = [
  "tokio-stream",
  "tracing",
  "url",
- "webpki-roots 0.26.5",
+ "webpki-roots 0.26.6",
 ]
 
 [[package]]
@@ -5730,9 +5686,9 @@ dependencies = [
 
 [[package]]
 name = "svgtypes"
-version = "0.15.1"
+version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fae3064df9b89391c9a76a0425a69d124aee9c5c28455204709e72c39868a43c"
+checksum = "794de53cc48eaabeed0ab6a3404a65f40b3e38c067e4435883a65d2aa4ca000e"
 dependencies = [
  "kurbo",
  "siphasher 1.0.1",
@@ -5833,17 +5789,17 @@ dependencies = [
 
 [[package]]
 name = "testcontainers"
-version = "0.22.0"
+version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ef8374cea2c164699681ecc39316c3e1d953831a7a5721e36c7736d974e15fa"
+checksum = "5f40cc2bd72e17f328faf8ca7687fe337e61bccd8acf9674fa78dd3792b045e1"
 dependencies = [
  "async-trait",
  "bollard",
  "bollard-stubs",
  "bytes",
- "dirs",
  "docker_credential",
  "either",
+ "etcetera",
  "futures",
  "log",
  "memchr",
@@ -5855,33 +5811,34 @@ dependencies = [
  "thiserror",
  "tokio",
  "tokio-stream",
+ "tokio-tar",
  "tokio-util",
  "url",
 ]
 
 [[package]]
 name = "testcontainers-modules"
-version = "0.10.0"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "359d9a225791e1b9f60aab01f9ae9471898b9b9904b5db192104a71e96785079"
+checksum = "ebd106a016d7b19e4c080c73c858d842fead9e420620ad873955569cc6bdac11"
 dependencies = [
  "testcontainers",
 ]
 
 [[package]]
 name = "thiserror"
-version = "1.0.63"
+version = "1.0.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0342370b38b6a11b6cc11d6a805569958d54cfa061a29969c3b5ce2ea405724"
+checksum = "d50af8abc119fb8bb6dbabcfa89656f46f84aa0ac7688088608076ad2b459a84"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.63"
+version = "1.0.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4558b58466b9ad7ca0f102865eccc95938dca1a74a856f2b57b6629050da261"
+checksum = "08904e7672f5eb876eaaf87e0ce17857500934f4981c4a0ab2b4aa98baac7fc3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6072,6 +6029,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-tar"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d5714c010ca3e5c27114c1cdeb9d14641ace49874aa5626d7149e47aedace75"
+dependencies = [
+ "filetime",
+ "futures-core",
+ "libc",
+ "redox_syscall 0.3.5",
+ "tokio",
+ "tokio-stream",
+ "xattr",
+]
+
+[[package]]
 name = "tokio-tungstenite"
 version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6084,7 +6056,7 @@ dependencies = [
  "tokio",
  "tokio-rustls 0.25.0",
  "tungstenite",
- "webpki-roots 0.26.5",
+ "webpki-roots 0.26.6",
 ]
 
 [[package]]
@@ -6214,6 +6186,7 @@ dependencies = [
  "tokio",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -6238,9 +6211,9 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.5.2"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e9cd434a998747dd2c4276bc96ee2e0c7a2eadf3cae88e52be55a05fa9053f5"
+checksum = "8437150ab6bbc8c5f0f519e3d5ed4aa883a83dd4cdd3d1b21f9482936046cb97"
 dependencies = [
  "async-compression",
  "bitflags 2.5.0",
@@ -6248,7 +6221,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "http 1.1.0",
- "http-body 1.0.0",
+ "http-body 1.0.1",
  "http-body-util",
  "http-range-header 0.4.0",
  "httpdate",
@@ -6271,16 +6244,16 @@ checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
 
 [[package]]
 name = "tower-livereload"
-version = "0.9.3"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57d7d9fecf1242d1c6a3cf8f7f3c2da94e6aac553bb7062ab6d03e16b9872fd0"
+checksum = "0eed2e2234e1daf043b5548205c29778f2655a00eba8fd980333506bb007f052"
 dependencies = [
  "bytes",
  "http 1.1.0",
- "http-body 1.0.0",
+ "http-body 1.0.1",
  "pin-project-lite",
  "tokio",
- "tower 0.4.13",
+ "tower 0.5.1",
 ]
 
 [[package]]
@@ -6295,7 +6268,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "313fa625fea5790ed56360a30ea980e41229cf482b4835801a67ef1922bf63b9"
 dependencies = [
- "axum 0.7.5",
+ "axum 0.7.7",
  "forwarded-header-value",
  "governor",
  "http 1.1.0",
@@ -6585,9 +6558,9 @@ checksum = "ad8d71f5726e5f285a935e9fe8edfd53f0491eb6e9a5774097fdabee7cd8c9cd"
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4c87d22b6e3f4a18d4d40ef354e97c90fcb14dd91d7dc0aa9d8a1172ebf7202"
+checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
 
 [[package]]
 name = "unicode-vo"
@@ -6633,9 +6606,9 @@ checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
 name = "usvg"
-version = "0.43.0"
+version = "0.44.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6803057b5cbb426e9fb8ce2216f3a9b4ca1dd2c705ba3cbebc13006e437735fd"
+checksum = "7447e703d7223b067607655e625e0dbca80822880248937da65966194c4864e6"
 dependencies = [
  "base64 0.22.1",
  "data-url 0.3.1",
@@ -6856,9 +6829,9 @@ checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
 
 [[package]]
 name = "webpki-roots"
-version = "0.26.5"
+version = "0.26.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bd24728e5af82c6c4ec1b66ac4844bdf8156257fccda846ec58b42cd0cdbe6a"
+checksum = "841c67bff177718f1d4dfefde8d8f0e78f9b6589319ba88312f567fc5841a958"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -6981,6 +6954,15 @@ name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets 0.52.6",
 ]
@@ -7144,6 +7126,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
 dependencies = [
  "tap",
+]
+
+[[package]]
+name = "xattr"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8da84f1a25939b27f6820d92aed108f83ff920fdf11a7b19366c27c4cda81d4f"
+dependencies = [
+ "libc",
+ "linux-raw-sys",
+ "rustix",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ members = [
 
 [profile.release]
 strip = true
+opt-level = "s"
 lto = "fat"
 codegen-units = 1
 panic = "abort"

--- a/rhombus/Cargo.toml
+++ b/rhombus/Cargo.toml
@@ -2,6 +2,7 @@
 name = "rhombus"
 version = "0.2.21"
 edition = "2021"
+rust-version = "1.80.0"
 description = "Next generation extendable CTF framework with batteries included"
 authors = ["Mark Bundschuh <mark@mbund.dev>"]
 license = "MPL-2.0"
@@ -12,7 +13,7 @@ keywords = ["web", "ctf", "http"]
 [dependencies]
 argon2 = { version = "0.5.3", features = ["std"] }
 async-hash = "0.5.4"
-async-imap = { version = "0.10.1", default-features = false, features = [
+async-imap = { version = "0.10.1", default-features = false, optional = true, features = [
   "runtime-tokio",
 ] }
 async-trait = "0.1.83"
@@ -24,16 +25,19 @@ dashmap = { version = "6.1.0", features = ["inline"] }
 dotenvy = "0.15.7"
 fancy-regex = "0.13.0"
 fluent = "0.16.1"
+futures = { version = "0.3.31", optional = true }
 healthscript = "1.0.3"
 intl-memoizer = "0.5.2"
 jsonwebtoken = "9.3.0"
-lettre = { version = "0.11.9", default-features = false, features = [
+lettre = { version = "0.11.9", default-features = false, optional = true, features = [
   "tokio1-rustls-tls",
   "smtp-transport",
   "builder",
   "pool",
 ] }
-mail-parser = "0.9.4"
+libsql = { version = "0.6.0", optional = true }
+listenfd = { version = "1.0.1", optional = true }
+mail-parser = { version = "0.9.4", optional = true }
 markdown = "1.0.0-alpha.21"
 mime_guess = "2.0.5"
 minify-html-onepass = "0.15.0"
@@ -48,15 +52,21 @@ reqwest = { version = "0.12.8", default-features = false, features = [
 resvg = "0.44.0"
 ring = "0.17.8"
 rust-embed = "8.5.0"
-rust-s3 = { version = "0.35.1", default-features = false, features = [
+rust-s3 = { version = "0.35.1", default-features = false, optional = true, features = [
   "tokio-rustls-tls",
 ] }
 serde = { version = "1.0.210", features = ["derive"] }
 serde_json = "1.0.128"
 serenity = { version = "0.12.2", features = ["chrono"] }
+sqlx = { version = "0.8.2", optional = true, features = [
+  "tls-rustls",
+  "runtime-tokio",
+  "chrono",
+  "macros",
+] }
 thiserror = "1.0.64"
 tokio = { version = "1.40.0", features = ["full"] }
-tokio-rustls = { version = "0.26.0", default-features = false, features = [
+tokio-rustls = { version = "0.26.0", default-features = false, optional = true, features = [
   "ring",
   "logging",
   "tls12",
@@ -70,17 +80,7 @@ tracing = "0.1.40"
 unic-langid = { version = "0.9.5", features = ["unic-langid-macros"] }
 unicode-segmentation = "1.12.0"
 urlencoding = "2.1.3"
-webpki-roots = "0.26.6"
-
-futures = { version = "0.3.31", optional = true }
-libsql = { version = "0.6.0", optional = true }
-listenfd = { version = "1.0.1", optional = true }
-sqlx = { version = "0.8.2", optional = true, features = [
-  "tls-rustls",
-  "runtime-tokio",
-  "chrono",
-  "macros",
-] }
+webpki-roots = { version = "0.26.6", optional = true }
 
 [build-dependencies]
 rustc_version = "0.4.1"
@@ -90,11 +90,20 @@ testcontainers = "0.23.1"
 testcontainers-modules = { version = "0.11.2", features = ["postgres"] }
 
 [features]
-default = ["libsql"]
+default = []
 postgres = ["dep:sqlx", "sqlx/postgres"]
 mysql = ["dep:sqlx", "sqlx/mysql"]
 libsql = ["dep:libsql", "dep:futures"]
 systemfd = ["dep:listenfd"]
+imap = [
+  "dep:async-imap",
+  "dep:futures",
+  "dep:mail-parser",
+  "dep:tokio-rustls",
+  "dep:webpki-roots",
+]
+smtp = ["dep:lettre"]
+s3 = ["dep:rust-s3", "dep:futures"]
 shuttle = []
 testcontainers = []
 internal = []
@@ -102,6 +111,9 @@ all = [
   "postgres",
   "mysql",
   "libsql",
+  "imap",
+  "smtp",
+  "s3",
   "systemfd",
   "shuttle",
   "testcontainers",

--- a/rhombus/Cargo.toml
+++ b/rhombus/Cargo.toml
@@ -15,9 +15,9 @@ async-hash = "0.5.4"
 async-imap = { version = "0.10.1", default-features = false, features = [
   "runtime-tokio",
 ] }
-async-trait = "0.1.82"
-axum = { version = "0.7.5", features = ["multipart"] }
-axum-extra = { version = "0.9.3", features = ["cookie"] }
+async-trait = "0.1.83"
+axum = { version = "0.7.7", features = ["multipart"] }
+axum-extra = { version = "0.9.4", features = ["cookie"] }
 chrono = { version = "0.4.38", features = ["serde"] }
 config = "0.14.0"
 dashmap = { version = "6.1.0", features = ["inline"] }
@@ -25,30 +25,27 @@ dotenvy = "0.15.7"
 fancy-regex = "0.13.0"
 fluent = "0.16.1"
 healthscript = "1.0.3"
-Inflector = "0.11.4"
 intl-memoizer = "0.5.2"
 jsonwebtoken = "9.3.0"
-lazy_static = "1.5.0"
-lettre = { version = "0.11.8", default-features = false, features = [
+lettre = { version = "0.11.9", default-features = false, features = [
   "tokio1-rustls-tls",
   "smtp-transport",
   "builder",
   "pool",
 ] }
 mail-parser = "0.9.4"
-markdown = "1.0.0-alpha.20"
+markdown = "1.0.0-alpha.21"
 mime_guess = "2.0.5"
 minify-html-onepass = "0.15.0"
 minijinja = { version = "2.3.1", features = ["json", "loader", "speedups"] }
-petname = "2.0.2"
 pin-project-lite = "0.2.14"
 poise = "0.6.1"
 rand = "0.8.5"
-reqwest = { version = "0.12.7", default-features = false, features = [
+reqwest = { version = "0.12.8", default-features = false, features = [
   "rustls-tls",
   "json",
 ] }
-resvg = "0.43.0"
+resvg = "0.44.0"
 ring = "0.17.8"
 rust-embed = "8.5.0"
 rust-s3 = { version = "0.35.1", default-features = false, features = [
@@ -57,8 +54,7 @@ rust-s3 = { version = "0.35.1", default-features = false, features = [
 serde = { version = "1.0.210", features = ["derive"] }
 serde_json = "1.0.128"
 serenity = { version = "0.12.2", features = ["chrono"] }
-thiserror = "1.0.63"
-time = "0.3.36"
+thiserror = "1.0.64"
 tokio = { version = "1.40.0", features = ["full"] }
 tokio-rustls = { version = "0.26.0", default-features = false, features = [
   "ring",
@@ -68,15 +64,15 @@ tokio-rustls = { version = "0.26.0", default-features = false, features = [
 tokio-util = { version = "0.7.12", features = ["io"] }
 tower = { version = "0.5.1", features = ["util", "make"] }
 tower_governor = "0.4.2"
-tower-http = { version = "0.5.2", features = ["compression-full", "fs"] }
-tower-livereload = "0.9.3"
+tower-http = { version = "0.6.1", features = ["compression-full", "fs"] }
+tower-livereload = "0.9.4"
 tracing = "0.1.40"
 unic-langid = { version = "0.9.5", features = ["unic-langid-macros"] }
-unicode-segmentation = "1.11.0"
+unicode-segmentation = "1.12.0"
 urlencoding = "2.1.3"
-webpki-roots = "0.26.5"
+webpki-roots = "0.26.6"
 
-futures = { version = "0.3.30", optional = true }
+futures = { version = "0.3.31", optional = true }
 libsql = { version = "0.6.0", optional = true }
 listenfd = { version = "1.0.1", optional = true }
 sqlx = { version = "0.8.2", optional = true, features = [
@@ -90,8 +86,8 @@ sqlx = { version = "0.8.2", optional = true, features = [
 rustc_version = "0.4.1"
 
 [dev-dependencies]
-testcontainers = "0.22.0"
-testcontainers-modules = { version = "0.10.0", features = ["postgres"] }
+testcontainers = "0.23.1"
+testcontainers-modules = { version = "0.11.2", features = ["postgres"] }
 
 [features]
 default = ["libsql"]

--- a/rhombus/Cargo.toml
+++ b/rhombus/Cargo.toml
@@ -12,7 +12,6 @@ keywords = ["web", "ctf", "http"]
 
 [dependencies]
 argon2 = { version = "0.5.3", features = ["std"] }
-async-hash = "0.5.4"
 async-imap = { version = "0.10.1", default-features = false, optional = true, features = [
   "runtime-tokio",
 ] }
@@ -42,7 +41,7 @@ markdown = "1.0.0-alpha.21"
 mime_guess = "2.0.5"
 minify-html-onepass = "0.15.0"
 minijinja = { version = "2.3.1", features = ["json", "loader", "speedups"] }
-pin-project-lite = "0.2.14"
+pin-project = "1.1.6"
 poise = "0.6.1"
 rand = "0.8.5"
 reqwest = { version = "0.12.8", default-features = false, features = [
@@ -71,8 +70,8 @@ tokio-rustls = { version = "0.26.0", default-features = false, optional = true, 
   "logging",
   "tls12",
 ] }
-tokio-util = { version = "0.7.12", features = ["io"] }
-tower = { version = "0.5.1", features = ["util", "make"] }
+tokio-util = "0.7.12"
+tower = "0.5.1"
 tower_governor = "0.4.2"
 tower-http = { version = "0.6.1", features = ["compression-full", "fs"] }
 tower-livereload = "0.9.4"

--- a/rhombus/src/challenge_loader_plugin.rs
+++ b/rhombus/src/challenge_loader_plugin.rs
@@ -6,7 +6,6 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use async_hash::{Digest, Sha256};
 use axum::Router;
 use config::Config;
 use futures::{StreamExt, TryFutureExt, TryStreamExt};
@@ -329,9 +328,8 @@ impl Plugin for ChallengeLoaderPlugin {
                             let src = challenge.root.join(src);
 
                             let data = tokio::fs::read(&src).await?;
-                            let mut hasher = Sha256::new();
-                            hasher.update(data);
-                            let hash = slice_to_hex_string(hasher.finalize().as_slice());
+                            let digest = ring::digest::digest(&ring::digest::SHA256, &data);
+                            let hash = slice_to_hex_string(digest.as_ref());
 
                             if let Some(previous) = previous {
                                 if previous.hash == hash {

--- a/rhombus/src/errors.rs
+++ b/rhombus/src/errors.rs
@@ -38,12 +38,15 @@ pub enum RhombusError {
     #[error("Discord: {0}")]
     Discord(#[from] serenity::Error),
 
+    #[cfg(feature = "smtp")]
     #[error("Email: {0}")]
     Email(#[from] lettre::address::AddressError),
 
+    #[cfg(feature = "smtp")]
     #[error("Email: {0}")]
     Email2(#[from] lettre::transport::smtp::Error),
 
+    #[cfg(feature = "smtp")]
     #[error("Email: {0}")]
     Email3(#[from] lettre::error::Error),
 
@@ -53,9 +56,11 @@ pub enum RhombusError {
     #[error("Reqwest error")]
     Reqwest(#[from] reqwest::Error),
 
+    #[cfg(feature = "s3")]
     #[error("S3 Error")]
     S3(#[from] s3::error::S3Error),
 
+    #[cfg(feature = "s3")]
     #[error("S3 Credentials Error")]
     S3Credentials(#[from] s3::creds::error::CredentialsError),
 

--- a/rhombus/src/internal/auth.rs
+++ b/rhombus/src/internal/auth.rs
@@ -1,6 +1,5 @@
 use std::{fmt::Write, net::IpAddr, num::NonZeroU64, sync::Arc};
 
-use async_hash::{Digest, Sha256};
 use axum::{
     body::Body,
     extract::{Query, State},
@@ -935,12 +934,15 @@ pub struct EmailSignInParams {
 }
 
 pub fn avatar_from_email(email: &str) -> String {
-    let hash = Sha256::digest(email.trim().to_lowercase().as_bytes())
-        .iter()
-        .fold(String::new(), |mut output, b| {
-            let _ = write!(output, "{:02x}", b);
-            output
-        });
+    let digest = ring::digest::digest(
+        &ring::digest::SHA256,
+        email.trim().to_lowercase().as_bytes(),
+    );
+
+    let hash = digest.as_ref().iter().fold(String::new(), |mut output, b| {
+        let _ = write!(output, "{:02x}", b);
+        output
+    });
 
     format!(
         "https://seccdn.libravatar.org/avatar/{}?s=80&default=retro",

--- a/rhombus/src/internal/database/cache.rs
+++ b/rhombus/src/internal/database/cache.rs
@@ -1,4 +1,10 @@
-use std::{collections::BTreeMap, net::IpAddr, num::NonZeroU64, sync::Arc, time::Duration};
+use std::{
+    collections::BTreeMap,
+    net::IpAddr,
+    num::NonZeroU64,
+    sync::{Arc, LazyLock},
+    time::Duration,
+};
 
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
@@ -548,9 +554,7 @@ impl Database for DbCache {
     }
 }
 
-lazy_static::lazy_static! {
-    pub static ref CHALLENGES_CACHE: RwLock<Option<Challenges>> = None.into();
-}
+pub static CHALLENGES_CACHE: LazyLock<RwLock<Option<Challenges>>> = LazyLock::new(RwLock::default);
 
 pub async fn get_challenges(db: &Connection) -> Result<Challenges> {
     if let Some(challenges) = &*CHALLENGES_CACHE.read().await {
@@ -568,9 +572,7 @@ pub async fn get_challenges(db: &Connection) -> Result<Challenges> {
     challenges
 }
 
-lazy_static::lazy_static! {
-    pub static ref TEAM_CACHE: DashMap<i64, TimedCache<Team>> = DashMap::new();
-}
+pub static TEAM_CACHE: LazyLock<DashMap<i64, TimedCache<Team>>> = LazyLock::new(DashMap::new);
 
 pub async fn get_team_from_id(db: &Connection, team_id: i64) -> Result<Team> {
     if let Some(team) = TEAM_CACHE.get(&team_id) {
@@ -601,9 +603,7 @@ impl<T> TimedCache<T> {
     }
 }
 
-lazy_static::lazy_static! {
-    pub static ref USER_CACHE: DashMap<i64, TimedCache<User>> = DashMap::new();
-}
+pub static USER_CACHE: LazyLock<DashMap<i64, TimedCache<User>>> = LazyLock::new(DashMap::new);
 
 pub async fn get_user_from_id(db: &Connection, user_id: i64) -> Result<User> {
     if let Some(user) = USER_CACHE.get(&user_id) {
@@ -621,9 +621,8 @@ pub async fn get_user_from_id(db: &Connection, user_id: i64) -> Result<User> {
 
 pub type Writeups = BTreeMap<i64, Writeup>;
 
-lazy_static::lazy_static! {
-    pub static ref USER_WRITEUP_CACHE: DashMap<i64, TimedCache<Writeups>> = DashMap::new();
-}
+pub static USER_WRITEUP_CACHE: LazyLock<DashMap<i64, TimedCache<Writeups>>> =
+    LazyLock::new(DashMap::new);
 
 pub async fn get_writeups_from_user_id(db: &Connection, user_id: i64) -> Result<Writeups> {
     if let Some(writeups) = USER_WRITEUP_CACHE.get(&user_id) {
@@ -639,9 +638,7 @@ pub async fn get_writeups_from_user_id(db: &Connection, user_id: i64) -> Result<
     writeups
 }
 
-lazy_static::lazy_static! {
-    pub static ref SCOREBOARD_CACHE: DashMap<i64, Scoreboard> = DashMap::new();
-}
+pub static SCOREBOARD_CACHE: LazyLock<DashMap<i64, Scoreboard>> = LazyLock::new(DashMap::new);
 
 pub async fn get_scoreboard(db: &Connection, division_id: i64) -> Result<Scoreboard> {
     if let Some(scoreboard) = SCOREBOARD_CACHE.get(&division_id) {
@@ -657,9 +654,8 @@ pub async fn get_scoreboard(db: &Connection, division_id: i64) -> Result<Scorebo
     scoreboard
 }
 
-lazy_static::lazy_static! {
-    pub static ref LEADERBOARD_CACHE: DashMap<(i64, Option<u64>), Leaderboard> = DashMap::new();
-}
+pub static LEADERBOARD_CACHE: LazyLock<DashMap<(i64, Option<u64>), Leaderboard>> =
+    LazyLock::new(DashMap::new);
 
 pub async fn get_leaderboard(
     db: &Connection,
@@ -679,9 +675,8 @@ pub async fn get_leaderboard(
     leaderboard
 }
 
-lazy_static::lazy_static! {
-    pub static ref USER_EMAILS_CACHE: DashMap<i64, TimedCache<Vec<Email>>> = DashMap::new();
-}
+pub static USER_EMAILS_CACHE: LazyLock<DashMap<i64, TimedCache<Vec<Email>>>> =
+    LazyLock::new(DashMap::new);
 
 pub async fn get_emails_for_user_id(db: &Connection, user_id: i64) -> Result<Vec<Email>> {
     if let Some(emails) = USER_EMAILS_CACHE.get(&user_id) {
@@ -697,9 +692,8 @@ pub async fn get_emails_for_user_id(db: &Connection, user_id: i64) -> Result<Vec
     emails
 }
 
-lazy_static::lazy_static! {
-    pub static ref TEAM_STANDINGS: DashMap<i64, TimedCache<Option<TeamStanding>>> = DashMap::new();
-}
+pub static TEAM_STANDINGS: LazyLock<DashMap<i64, TimedCache<Option<TeamStanding>>>> =
+    LazyLock::new(DashMap::new);
 
 pub async fn get_team_standing(
     db: &Connection,

--- a/rhombus/src/internal/discord.rs
+++ b/rhombus/src/internal/discord.rs
@@ -2,7 +2,7 @@ use std::{
     borrow::Cow,
     collections::{btree_map, BTreeMap},
     num::NonZeroU64,
-    sync::Arc,
+    sync::{Arc, LazyLock},
 };
 
 use chrono::{DateTime, Utc};
@@ -316,9 +316,8 @@ Default Ticket Template
     Ok(())
 }
 
-lazy_static::lazy_static! {
-    pub static ref DIGEST_DEBOUNCER: Mutex<BTreeMap<ChannelId, i64>> = Default::default();
-}
+pub static DIGEST_DEBOUNCER: LazyLock<Mutex<BTreeMap<ChannelId, i64>>> =
+    LazyLock::new(Mutex::default);
 
 #[derive(Debug, Serialize, PartialEq, Eq, PartialOrd, Ord)]
 pub struct DigestAuthor {
@@ -962,12 +961,12 @@ pub struct DiscordInviteUrlCache {
     pub timestamp: i64,
 }
 
-lazy_static::lazy_static! {
-    pub static ref INVITE_URL_CACHE: RwLock<DiscordInviteUrlCache> = RwLock::new(DiscordInviteUrlCache {
+pub static INVITE_URL_CACHE: LazyLock<RwLock<DiscordInviteUrlCache>> = LazyLock::new(|| {
+    RwLock::new(DiscordInviteUrlCache {
         url: String::new(),
         timestamp: 0,
-    });
-}
+    })
+});
 
 fn escape_discord_link(input: &str) -> Cow<str> {
     // Discord markdown parsing is frustration.

--- a/rhombus/src/internal/email/mod.rs
+++ b/rhombus/src/internal/email/mod.rs
@@ -1,6 +1,11 @@
-pub mod imap;
 pub mod mailgun;
 pub mod outbound_mailer;
 pub mod provider;
-pub mod reply_parser;
+
+#[cfg(feature = "smtp")]
 pub mod smtp;
+
+#[cfg(feature = "imap")]
+pub mod imap;
+#[cfg(feature = "imap")]
+pub mod reply_parser;

--- a/rhombus/src/internal/email/provider.rs
+++ b/rhombus/src/internal/email/provider.rs
@@ -1,5 +1,6 @@
-use crate::Result;
 use axum::async_trait;
+
+use crate::Result;
 
 #[async_trait]
 pub trait OutboundEmailProvider {
@@ -14,7 +15,7 @@ pub trait OutboundEmailProvider {
     ) -> Result<String>;
 }
 
-#[allow(async_fn_in_trait)]
+#[allow(async_fn_in_trait, dead_code)]
 pub trait InboundEmail {
     async fn receive_emails(&self) -> Result<()>;
 }

--- a/rhombus/src/internal/ip.rs
+++ b/rhombus/src/internal/ip.rs
@@ -9,6 +9,7 @@ use axum::{
 use dashmap::DashMap;
 use std::{
     net::{IpAddr, SocketAddr},
+    sync::LazyLock,
     time::Duration,
 };
 use tower_governor::{key_extractor::KeyExtractor, GovernorError};
@@ -43,9 +44,9 @@ pub fn track_flusher(db: Connection) {
     });
 }
 
-lazy_static::lazy_static! {
-    pub static ref TRACK_CACHE: DashMap<(IpAddr, Option<String>, Option<i64>), u64> = DashMap::new();
-}
+pub type TrackKey = (IpAddr, Option<String>, Option<i64>);
+
+pub static TRACK_CACHE: LazyLock<DashMap<TrackKey, u64>> = LazyLock::new(DashMap::new);
 
 /// Middleware to log the IP and user agent of the client in the database as track.
 /// Associates the track with the user if the user is logged in. Runs asynchronously,

--- a/rhombus/src/internal/local_upload_provider.rs
+++ b/rhombus/src/internal/local_upload_provider.rs
@@ -1,13 +1,12 @@
 use std::{fmt::Write, sync::Arc, task::Poll};
 
-use async_hash::{Digest, Sha256};
 use axum::{
     body::Body,
     extract::{Request, State},
     response::IntoResponse,
     Extension,
 };
-use pin_project_lite::pin_project;
+use pin_project::pin_project;
 use reqwest::StatusCode;
 use tokio::io::AsyncRead;
 use tower_http::services::ServeFile;
@@ -67,25 +66,24 @@ pub fn slice_to_hex_string(slice: &[u8]) -> String {
     })
 }
 
-pin_project! {
-    pub struct HashRead<T> {
-        #[pin]
-        read: T,
+#[pin_project]
+pub struct HashRead<T> {
+    #[pin]
+    read: T,
 
-        hasher: Sha256,
-    }
+    hasher: ring::digest::Context,
 }
 
 impl<T> HashRead<T> {
     pub fn new(read: T) -> Self {
         Self {
             read,
-            hasher: Sha256::new(),
+            hasher: ring::digest::Context::new(&ring::digest::SHA256),
         }
     }
 
     pub fn hash(self) -> Vec<u8> {
-        self.hasher.finalize().as_slice().into()
+        self.hasher.finish().as_ref().into()
     }
 }
 

--- a/rhombus/src/internal/routes/account.rs
+++ b/rhombus/src/internal/routes/account.rs
@@ -1,4 +1,4 @@
-use std::{collections::BTreeMap, net::IpAddr, num::NonZeroU64, time::Duration};
+use std::{collections::BTreeMap, net::IpAddr, num::NonZeroU64, sync::LazyLock, time::Duration};
 
 use axum::{
     extract::{Query, State},
@@ -29,9 +29,8 @@ pub fn generate_email_callback_code() -> String {
     Alphanumeric.sample_string(&mut thread_rng(), 16)
 }
 
-lazy_static::lazy_static! {
-    pub static ref IS_IN_SERVER_CACHE: DashMap<NonZeroU64, TimedCache<bool>> = DashMap::new();
-}
+pub static IS_IN_SERVER_CACHE: LazyLock<DashMap<NonZeroU64, TimedCache<bool>>> =
+    LazyLock::new(DashMap::new);
 
 async fn is_in_server(
     discord_guild_id: NonZeroU64,

--- a/rhombus/src/internal/routes/challenges.rs
+++ b/rhombus/src/internal/routes/challenges.rs
@@ -1,4 +1,4 @@
-use std::time::Duration;
+use std::{sync::LazyLock, time::Duration};
 
 use axum::{
     extract::{Path, State},
@@ -478,13 +478,11 @@ pub async fn route_ticket_submit(
         .into_response()
 }
 
+pub static TEAM_BURSTED_POINTS: LazyLock<DashMap<i64, i64>> = LazyLock::new(DashMap::new);
+
 #[derive(Deserialize)]
 pub struct SubmitChallenge {
     flag: String,
-}
-
-lazy_static::lazy_static! {
-    pub static ref TEAM_BURSTED_POINTS: DashMap<i64, i64> = DashMap::new();
 }
 
 pub async fn route_challenge_submit(

--- a/rhombus/src/lib.rs
+++ b/rhombus/src/lib.rs
@@ -23,8 +23,10 @@ pub mod challenge_loader_plugin;
 pub mod database_upload_provider;
 mod local_upload_provider;
 pub mod plugin;
-pub mod s3_upload_provider;
 mod upload_provider;
+
+#[cfg(feature = "s3")]
+pub mod s3_upload_provider;
 
 #[cfg(feature = "systemfd")]
 mod systemfd;

--- a/rhombus/src/s3_upload_provider.rs
+++ b/rhombus/src/s3_upload_provider.rs
@@ -1,6 +1,5 @@
 use std::{io, str::FromStr, sync::Arc};
 
-use async_hash::{Digest, Sha256};
 use axum::{body::Bytes, routing::post, Router};
 use futures::{Stream, TryStreamExt};
 
@@ -93,9 +92,8 @@ impl UploadProvider for S3UploadProvider {
             }
         }
 
-        let mut hasher = Sha256::new();
-        hasher.update(&buffer);
-        let hash = slice_to_hex_string(hasher.finalize().as_slice());
+        let digest = ring::digest::digest(&ring::digest::SHA256, &buffer);
+        let hash = slice_to_hex_string(digest.as_ref());
 
         let s3_path = format!("{}{}/{}", self.prefix, hash, filename);
 

--- a/rhombus/templates/public-team.html
+++ b/rhombus/templates/public-team.html
@@ -5,7 +5,7 @@
   <div class="container my-4">
     <div class="mb-4 space-y-0.5">
       <h2 id="title" class="text-2xl font-bold tracking-tight">
-        Team {{ public_team.name }}
+        {{ public_team.name }}
       </h2>
       <p class="text-muted-foreground">
         Public team profile.

--- a/rhombus/templates/public-user.html
+++ b/rhombus/templates/public-user.html
@@ -5,7 +5,7 @@
   <div class="container my-4">
     <div class="mb-4 space-y-0.5">
       <h2 id="title" class="text-2xl font-bold tracking-tight">
-        User {{ public_user.name }}
+        {{ public_user.name }}
       </h2>
       <p class="text-muted-foreground">
         On team


### PR DESCRIPTION
Remove
- `petname`, `Inflector`
  - Replaced with just `Team X` where `X` is the team id
- `time`
  - Was only used in `auth.rs`
  - Replaced with `.removal()` for clearing cookie, and simply the JWT's `exp` field instead of the cookie's `max_age`
- `lazy_static`
  - replaced with Rust 1.80.0's `LazyLock`
- `async-hash`
  - Replace with `ring` which is required for mailgun already/anyways

Feature gates
- `imap`
- `smtp`
- `s3`
