### PR TITLE
Improve wrapping for challenge names

### DIFF
--- a/rhombus/templates/challenges/challenges.html
+++ b/rhombus/templates/challenges/challenges.html
@@ -33,13 +33,14 @@
               class="bg-card ring-offset-background border-l-4 p-4 ring-offset-4"
               style="border-color: {{ category.color }}; --tw-ring-color: {{ category.color }}"
             >
-              <div class="mb-2 flex h-8 justify-between">
+              <div class="mb-2 flex h-8 gap-2 justify-between">
                 <div class="flex items-center gap-2 font-bold">
                   <button
                     hx-trigger="click"
                     hx-get="/challenges/{{ challenge.id }}"
                     hx-target="body"
                     hx-swap="beforeend"
+                    class="text-left"
                   >
                     <span style="color: {{ category.color }}">
                       {{ category.name }} /
@@ -67,7 +68,7 @@
                       />
                     </a>
                   {% endif %}
-                  <span class="cursor-pointer"
+                  <span class="cursor-pointer whitespace-nowrap"
                     >{{ t("solves-points", solves=challenge.division_solves | items | list | map("last") | sum, points=(solve.points if solve and solve.points else challenge.points)) }}</span
                   >
                   <img

--- a/rhombus/templates/challenges/challenges.html
+++ b/rhombus/templates/challenges/challenges.html
@@ -33,7 +33,7 @@
               class="bg-card ring-offset-background border-l-4 p-4 ring-offset-4"
               style="border-color: {{ category.color }}; --tw-ring-color: {{ category.color }}"
             >
-              <div class="mb-2 flex h-8 gap-2 justify-between">
+              <div class="mb-2 flex h-8 justify-between gap-2">
                 <div class="flex items-center gap-2 font-bold">
                   <button
                     hx-trigger="click"


### PR DESCRIPTION
Before:
<img width="666" height="81" alt="Screenshot From 2025-10-24 01-11-42" src="https://github.com/user-attachments/assets/5bb20ef4-fcb5-434e-bf45-05121f0623fa" />

After:
<img width="666" height="80" alt="Screenshot From 2025-10-24 01-07-03" src="https://github.com/user-attachments/assets/867b0ada-2c73-4078-ab23-061f8a79c112" />

Unfortunately [it's not possible to get the dot to go next to the wrapped text due to css limitations](https://www.reddit.com/r/css/comments/1fqabpb/flexbox_with_wrapped_text_leaves_undesired_empty/) but I think this is a lot better
